### PR TITLE
Bulk remove map

### DIFF
--- a/client/index.mjs
+++ b/client/index.mjs
@@ -1,6 +1,6 @@
 // @ts-check */
 import { z } from 'zod'
-import { bulkGet, bulkSave, bulkRemove, bulkGetDictionary, bulkSaveTransaction } from './impl/bulk.mjs'
+import { bulkGet, bulkSave, bulkRemove, bulkRemoveMap, bulkGetDictionary, bulkSaveTransaction } from './impl/bulk.mjs'
 import { get, put, getAtRev } from './impl/crud.mjs'
 import { changes } from './impl/changes.mjs'
 import { patch, patchDangerously } from './impl/patch.mjs'
@@ -11,7 +11,7 @@ import { queryStream } from './impl/stream.mjs'
 import { createQuery } from './impl/queryBuilder.mjs'
 import { getDBInfo } from './impl/util.mjs'
 import { withRetry } from './impl/retry.mjs'
-import { BulkSave, BulkGet, BulkRemove, BulkGetDictionary, BulkSaveTransaction } from './schema/bulk.mjs'
+import { BulkSave, BulkGet, BulkRemove, BulkRemoveMap, BulkGetDictionary, BulkSaveTransaction } from './schema/bulk.mjs'
 import { CouchConfig } from './schema/config.mjs'
 import { SimpleViewQuery, SimpleViewQueryResponse } from './schema/query.mjs'
 import { Changes, ChangesOptions, ChangesResponse } from './schema/changes.mjs'
@@ -32,6 +32,7 @@ const schema = {
   BulkSave,
   BulkGet,
   BulkRemove,
+  BulkRemoveMap,
   BulkGetDictionary,
   BulkSaveTransaction,
   CouchGet,
@@ -76,6 +77,7 @@ function doBind (config) {
     patch: config.bindWithRetry ? withRetry(patch.bind(null, config), retryOptions) : patch.bind(null, config),
     patchDangerously: patchDangerously.bind(null, config), // patchDangerously not included in retry
     bulkRemove: config.bindWithRetry ? withRetry(bulkRemove.bind(null, config), retryOptions) : bulkRemove.bind(null, config),
+    bulkRemoveMap: config.bindWithRetry ? withRetry(bulkRemoveMap.bind(null, config), retryOptions) : bulkRemoveMap.bind(null, config),
     bulkGetDictionary: config.bindWithRetry ? withRetry(bulkGetDictionary.bind(null, config), retryOptions) : bulkGetDictionary.bind(null, config),
     bulkSaveTransaction: bulkSaveTransaction.bind(null, config),
     createLock: createLock.bind(null, config),
@@ -130,6 +132,7 @@ export {
   patch,
   patchDangerously,
   bulkRemove,
+  bulkRemoveMap,
   bulkGetDictionary,
   bulkSaveTransaction,
 

--- a/client/schema/bind.mjs
+++ b/client/schema/bind.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { z } from 'zod'
 import { CouchConfig } from './config.mjs'
-import { BulkSaveBound, BulkGetBound, BulkRemoveBound, BulkGetDictionaryBound, BulkSaveTransactionBound } from './bulk.mjs'
+import { BulkSaveBound, BulkGetBound, BulkRemoveBound, BulkRemoveMapBound, BulkGetDictionaryBound, BulkSaveTransactionBound } from './bulk.mjs'
 import { CouchGetBound, CouchPutBound, CouchGetAtRevBound } from './crud.mjs'
 import { PatchBound } from './patch.mjs'
 import { SimpleViewQueryBound } from './query.mjs'
@@ -15,6 +15,7 @@ export const BindBase = z.object({
   bulkGet: BulkGetBound,
   bulkSave: BulkSaveBound,
   bulkRemove: BulkRemoveBound,
+  bulkRemoveMap: BulkRemoveMapBound,
   bulkGetDictionary: BulkGetDictionaryBound,
   bulkSaveTransaction: BulkSaveTransactionBound,
   get: CouchGetBound,

--- a/client/schema/bulk.mjs
+++ b/client/schema/bulk.mjs
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { CouchConfig } from './config.mjs'
 import { SimpleViewQueryResponse, ViewRow } from './query.mjs'
-import { CouchDoc } from './crud.mjs'
+import { CouchDoc, CouchDocResponse } from './crud.mjs'
 
 export const BulkSaveRow = z.object({
   ok: z.boolean().nullish(),
@@ -14,6 +14,9 @@ export const BulkSaveRow = z.object({
 
 export const BulkSaveResponseSchema = z.array(BulkSaveRow)
 /** @typedef { z.infer<typeof BulkSaveResponseSchema> } Response */
+
+export const BulkSaveMapResponseSchema = z.array(CouchDocResponse)
+/** @typedef { z.infer<typeof BulkSaveMapResponseSchema> } ResponseMap */
 
 export const OptionalIdCouchDoc = CouchDoc.extend({
   _id: CouchDoc.shape._id.optional()
@@ -51,6 +54,17 @@ export const BulkRemoveBound = z.function().args(
   z.array(z.string().describe('the ids to delete'))
 ).returns(z.promise(BulkSaveResponseSchema))
 /** @typedef { z.infer<typeof BulkRemoveBound> } BulkRemoveBoundSchema */
+
+export const BulkRemoveMap = z.function().args(
+  CouchConfig,
+  z.array(z.string().describe('the ids to delete'))
+).returns(z.promise(z.array(CouchDocResponse)))
+/** @typedef { z.infer<typeof BulkRemoveMap> } BulkRemoveMapSchema */
+
+export const BulkRemoveMapBound = z.function().args(
+  z.array(z.string().describe('the ids to delete'))
+).returns(z.promise(BulkSaveMapResponseSchema))
+/** @typedef { z.infer<typeof BulkRemoveMapBound> } BulkRemoveMapBoundSchema */
 
 export const BulkGetDictionaryResponse = z.object({
   found: z.record(z.string(), CouchDoc),

--- a/client/tests/test.mjs
+++ b/client/tests/test.mjs
@@ -262,6 +262,18 @@ test.test('full db tests', async t => {
     t.equal(results2.length, 1)
     t.end()
   })
+  t.test('bulkRemoveMap', async t => {
+    const results = await db.bulkRemoveMap(['test-doc-never52'])
+    t.ok(results)
+    t.equal(results.length, 0) // not an actual doc
+
+    const doc = await db.put({ _id: 'test-doc-never52', data: 'hello world' })
+    t.ok(doc.ok, 'Document created')
+    const results2 = await db.bulkRemoveMap(['test-doc-never52'])
+    t.ok(results2)
+    t.equal(results2.length, 1)
+    t.end()
+  })
   t.test('bulk save', async t => {
     // make sure docs with no id are accepted
     const docs = [{ first: true }, { _id: 'bbbbb', second: true }]


### PR DESCRIPTION
Add bulk-remove-map function that is similar to bulk-remove, only difference is it will step through each doc and get-put instead of using actual bulk-get and bulk-save.

This is mainly a method to work with large-data documents.